### PR TITLE
feat: Implement Model-Centric Repository Pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A lightweight and flexible ORM for Go, designed for simplicity and ease of use w
 *   **Lightweight:** Minimal dependencies and a focus on performance.
 *   **Transactions:** Support for database transactions with `BeginTx`, `Commit`, and `Rollback`.
 *   **Prepared Statements:** Built-in protection against SQL injection vulnerabilities.
+*   **Model-Centric Repository:** High-level CRUD operations (Save, FindByID, Delete) using Go structs.
 
 ## Planned Features
 *   **Data Stores:** Interface-based data stores for flexible data access patterns (e.g., SQLite, API).
@@ -93,7 +94,61 @@ func main() {
 	}
 }
 ```
-Advanced Usage
+### 6. Using the Repository for CRUD Operations
+
+The `Repository` provides a high-level, model-centric interface for performing common database operations.
+
+```go
+import (
+	"log"
+	"github.com/pballentine13/liteforge"
+	"github.com/pballentine13/liteforge/pkg/model"
+)
+
+func main() {
+	// ... (Database connection and table creation code from above)
+
+	repo := liteforge.NewRepository(db)
+
+	// 1. INSERT (Save a new user)
+	newUser := &model.User{
+		Name:  "Alice",
+		Email: "alice@example.com",
+	}
+	result, err := repo.Save(newUser) // Save handles INSERT when ID is 0
+	if err != nil {
+		log.Fatal(err)
+	}
+	newID, _ := result.LastInsertId()
+	newUser.ID = int(newID)
+	log.Printf("Inserted user with ID: %d", newUser.ID)
+
+	// 2. SELECT (Find by ID)
+	foundUser := &model.User{}
+	err = repo.FindByID(foundUser, newUser.ID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Found user: %+v", foundUser)
+
+	// 3. UPDATE (Save an existing user)
+	foundUser.Email = "alice.updated@example.com"
+	_, err = repo.Save(foundUser) // Save handles UPDATE when ID is non-zero
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Updated user: %s", foundUser.Email)
+
+	// 4. DELETE
+	_, err = repo.Delete(foundUser)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Deleted user with ID: %d", foundUser.ID)
+}
+```
+
+### Advanced Usage
 Custom Queries
 ```go
 rows, err := liteforge.Query(db, "SELECT * FROM users WHERE name LIKE ?", "%John%")

--- a/internal/orm/table.go
+++ b/internal/orm/table.go
@@ -68,6 +68,25 @@ func GetPrimaryKeyColumn(model any) (string, error) {
 	return "", errors.New("model has no primary key field (tag: `pk:\"true\"`)")
 }
 
+// GetPrimaryKeyValue extracts the value of the primary key field from a struct.
+func GetPrimaryKeyValue(model any) (any, error) {
+	val := reflect.ValueOf(model)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	t := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := t.Field(i)
+		pkTag := field.Tag.Get("pk")
+		if pkTag == "true" {
+			return val.Field(i).Interface(), nil
+		}
+	}
+
+	return nil, errors.New("model has no primary key field (tag: `pk:\"true\"`)")
+}
+
 // CreateTable creates a database table based on the provided model using the Datastore's adapter.
 func CreateTable(ds *Datastore, model any) error {
 

--- a/liteforge.go
+++ b/liteforge.go
@@ -2,10 +2,17 @@ package liteforge
 
 import (
 	"github.com/pballentine13/liteforge/internal/orm"
+	"github.com/pballentine13/liteforge/pkg/model"
 )
 
 type Config = orm.Config
 type Datastore = orm.Datastore
+
+// Repository is the high-level, model-centric interface for CRUD operations.
+type Repository = model.Repository
+
+// NewRepository creates a new model-centric repository.
+var NewRepository = model.NewORMRepository
 
 var OpenDB = orm.OpenDB
 var CreateTable = orm.CreateTable

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1,1 +1,212 @@
 package model
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pballentine13/liteforge/internal/orm"
+)
+
+// Repository defines the high-level, model-centric interface for CRUD operations.
+type Repository interface {
+	// Save handles both INSERT (if ID is zero/default) and UPDATE (if ID is set).
+	Save(model any) (sql.Result, error)
+	// FindByID populates the provided model struct with data for the given ID.
+	FindByID(model any, id int) error
+	// Update explicitly updates an existing record.
+	Update(model any) (sql.Result, error)
+	// Delete deletes a record based on the model's primary key.
+	Delete(model any) (sql.Result, error)
+}
+
+// ORMRepository is a concrete implementation of the Repository interface
+// that holds a reference to *orm.Datastore.
+type ORMRepository struct {
+	DS *orm.Datastore
+}
+
+// NewORMRepository creates a new ORMRepository instance.
+func NewORMRepository(ds *orm.Datastore) *ORMRepository {
+	return &ORMRepository{DS: ds}
+}
+
+// Save handles both INSERT and UPDATE.
+// It checks the primary key value to determine the operation.
+func (r *ORMRepository) Save(model any) (sql.Result, error) {
+	if r.DS == nil {
+		return nil, fmt.Errorf("datastore is nil")
+	}
+
+	pkValue, err := orm.GetPrimaryKeyValue(model)
+	if err != nil {
+		// If no PK is found, default to Insert.
+		return orm.Insert(r.DS, model)
+	}
+
+	// Check if the PK value is zero/default (e.g., 0 for int).
+	v := reflect.ValueOf(pkValue)
+	if v.Kind() == reflect.Int || v.Kind() == reflect.Int64 {
+		if v.Int() == 0 {
+			return orm.Insert(r.DS, model)
+		}
+	}
+
+	// If PK is set (non-zero int), perform an update.
+	return r.Update(model)
+}
+
+// FindByID populates the provided model struct with data for the given ID.
+func (r *ORMRepository) FindByID(model any, id int) error {
+	if r.DS == nil {
+		return fmt.Errorf("datastore is nil")
+	}
+
+	// Ensure model is a non-nil pointer to a struct
+	v := reflect.ValueOf(model)
+	if v.Kind() != reflect.Ptr || v.IsNil() || v.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("model must be a non-nil pointer to a struct")
+	}
+	v = v.Elem()
+	t := v.Type()
+
+	// 1. Get table name and column names
+	tableName := orm.GetTableName(model)
+	columns, _ := orm.GetFieldInfo(model) // columns are DB column names (lowercase field names)
+
+	if len(columns) == 0 {
+		return fmt.Errorf("model has no fields to query")
+	}
+
+	// 2. Get primary key column name
+	pkCol, err := orm.GetPrimaryKeyColumn(model)
+	if err != nil {
+		return fmt.Errorf("model must have a primary key field with 'pk' tag: %w", err)
+	}
+
+	// 3. Build the query
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE %s = %s",
+		strings.Join(columns, ", "),
+		tableName,
+		pkCol,
+		r.DS.Adapter.GetPlaceholder(1),
+	)
+
+	// 4. Execute the query
+	row, err := orm.QueryRow(r.DS, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to query row: %w", err)
+	}
+
+	// 5. Prepare destination pointers for Scan
+	dest := make([]any, len(columns))
+	for i, col := range columns {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		// Safety check: ensure the column name matches the lowercase field name
+		if strings.ToLower(field.Name) != col {
+			// This should not happen if GetFieldInfo is correct, but is a good safeguard.
+			return fmt.Errorf("internal error: column name mismatch for index %d: expected %s, got %s", i, strings.ToLower(field.Name), col)
+		}
+
+		if !fieldValue.CanSet() {
+			return fmt.Errorf("field %s is not settable", field.Name)
+		}
+		dest[i] = fieldValue.Addr().Interface()
+	}
+
+	// 6. Scan the row
+	if err := row.Scan(dest...); err != nil {
+		if err == sql.ErrNoRows {
+			return err
+		}
+		return fmt.Errorf("failed to scan row into model: %w", err)
+	}
+
+	return nil
+}
+
+// Update explicitly updates an existing record.
+func (r *ORMRepository) Update(model any) (sql.Result, error) {
+	if r.DS == nil {
+		return nil, fmt.Errorf("datastore is nil")
+	}
+
+	// 1. Get table name, columns, and values
+	tableName := orm.GetTableName(model)
+	columns, values := orm.GetFieldInfo(model)
+
+	// 2. Get primary key column and value
+	pkCol, err := orm.GetPrimaryKeyColumn(model)
+	if err != nil {
+		return nil, fmt.Errorf("model must have a primary key field with 'pk' tag: %w", err)
+	}
+	pkValue, err := orm.GetPrimaryKeyValue(model)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get primary key value: %w", err)
+	}
+
+	// 3. Build SET clause and new values slice (excluding PK)
+	setClauses := make([]string, 0, len(columns))
+	updateValues := make([]any, 0, len(values))
+	placeholderIndex := 1
+
+	for i, col := range columns {
+		if col == pkCol {
+			continue // Skip primary key in SET clause
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = %s", col, r.DS.Adapter.GetPlaceholder(placeholderIndex)))
+		updateValues = append(updateValues, values[i])
+		placeholderIndex++
+	}
+
+	if len(setClauses) == 0 {
+		return nil, fmt.Errorf("no fields to update")
+	}
+
+	// 4. Append PK value to the end of the values slice for the WHERE clause
+	updateValues = append(updateValues, pkValue)
+
+	// 5. Build the query
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE %s = %s",
+		tableName,
+		strings.Join(setClauses, ", "),
+		pkCol,
+		r.DS.Adapter.GetPlaceholder(placeholderIndex), // The last placeholder for the PK value
+	)
+
+	// 6. Execute the query
+	return orm.Exec(r.DS, query, updateValues...)
+}
+
+// Delete deletes a record based on the model's primary key.
+func (r *ORMRepository) Delete(model any) (sql.Result, error) {
+	if r.DS == nil {
+		return nil, fmt.Errorf("datastore is nil")
+	}
+
+	// 1. Get table name
+	tableName := orm.GetTableName(model)
+
+	// 2. Get primary key column and value
+	pkCol, err := orm.GetPrimaryKeyColumn(model)
+	if err != nil {
+		return nil, fmt.Errorf("model must have a primary key field with 'pk' tag: %w", err)
+	}
+	pkValue, err := orm.GetPrimaryKeyValue(model)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get primary key value: %w", err)
+	}
+
+	// 3. Build the query
+	query := fmt.Sprintf("DELETE FROM %s WHERE %s = %s",
+		tableName,
+		pkCol,
+		r.DS.Adapter.GetPlaceholder(1),
+	)
+
+	// 4. Execute the query
+	return orm.Exec(r.DS, query, pkValue)
+}

--- a/test/repository_test.go
+++ b/test/repository_test.go
@@ -1,0 +1,232 @@
+package lightforge
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pballentine13/liteforge"
+)
+
+// setupTestDB initializes an in-memory SQLite database, creates the TestUser table,
+// and returns a liteforge.Repository and a cleanup function.
+func setupTestDB(t *testing.T) (liteforge.Repository, func()) {
+	cfg := liteforge.Config{
+		DriverName:     "sqlite3",
+		DataSourceName: ":memory:",
+	}
+
+	ds, err := liteforge.OpenDB(cfg)
+	if err != nil {
+		t.Fatalf("Failed to open test database: %v", err)
+	}
+
+	// Create the table
+	err = liteforge.CreateTable(ds, TestUser{})
+	if err != nil {
+		ds.DB.Close()
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	repo := liteforge.NewRepository(ds)
+
+	cleanup := func() {
+		ds.DB.Close()
+	}
+
+	return repo, cleanup
+}
+
+func TestRepository_Save_Insert(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	user := &TestUser{
+		Username: "testuser_insert",
+		Email:    "insert@example.com",
+		Age:      30,
+		IsActive: true,
+	}
+
+	// 1. Test INSERT (ID is zero)
+	result, err := repo.Save(user)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	lastID, err := result.LastInsertId()
+	assert.NoError(t, err)
+	assert.True(t, lastID > 0)
+
+	// 2. Verify insertion by finding the record
+	foundUser := &TestUser{}
+	err = repo.FindByID(foundUser, int(lastID))
+	assert.NoError(t, err)
+	assert.Equal(t, int(lastID), foundUser.ID)
+	assert.Equal(t, user.Username, foundUser.Username)
+	assert.Equal(t, user.Email, foundUser.Email)
+	assert.Equal(t, user.Age, foundUser.Age)
+	assert.Equal(t, user.IsActive, foundUser.IsActive)
+}
+
+func TestRepository_Save_Update(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Setup: Insert a record first
+	user := &TestUser{
+		Username: "testuser_update",
+		Email:    "original@example.com",
+		Age:      25,
+		IsActive: false,
+	}
+	result, err := repo.Save(user)
+	assert.NoError(t, err)
+	lastID, _ := result.LastInsertId()
+
+	// Manually set the ID on the model for the update operation
+	user.ID = int(lastID)
+
+	// 1. Test UPDATE (ID is non-zero)
+	user.Email = "updated@example.com"
+	user.Age = 50
+	user.IsActive = true
+
+	result, err = repo.Save(user) // Should call Update because ID is non-zero
+	assert.NoError(t, err)
+
+	rowsAffected, err := result.RowsAffected()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rowsAffected)
+
+	// 2. Verify update by finding the record
+	foundUser := &TestUser{}
+	err = repo.FindByID(foundUser, user.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, user.ID, foundUser.ID)
+	assert.Equal(t, "updated@example.com", foundUser.Email)
+	assert.Equal(t, 50, foundUser.Age)
+	assert.Equal(t, true, foundUser.IsActive)
+}
+
+func TestRepository_FindByID(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Setup: Insert a record
+	user := &TestUser{
+		Username: "find_test",
+		Email:    "find@example.com",
+		Age:      40,
+		IsActive: true,
+	}
+	result, _ := repo.Save(user)
+	lastID, _ := result.LastInsertId()
+
+	// 1. Test successful retrieval
+	t.Run("Success", func(t *testing.T) {
+		foundUser := &TestUser{}
+		err := repo.FindByID(foundUser, int(lastID))
+		assert.NoError(t, err)
+		assert.Equal(t, int(lastID), foundUser.ID)
+		assert.Equal(t, user.Username, foundUser.Username)
+	})
+
+	// 2. Test record not found
+	t.Run("NotFound", func(t *testing.T) {
+		notFoundUser := &TestUser{}
+		// Use an ID that definitely doesn't exist
+		err := repo.FindByID(notFoundUser, 99999)
+		assert.ErrorIs(t, err, sql.ErrNoRows)
+		// Ensure the model is not populated (ID should be zero)
+		assert.Equal(t, 0, notFoundUser.ID)
+	})
+
+	// 3. Test invalid model input (edge case/error path)
+	t.Run("InvalidModel", func(t *testing.T) {
+		err := repo.FindByID(TestUser{}, int(lastID)) // Pass struct instead of pointer
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "model must be a non-nil pointer to a struct")
+	})
+}
+
+func TestRepository_Update(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Setup: Insert a record
+	user := &TestUser{
+		Username: "update_explicit",
+		Email:    "pre_update@example.com",
+		Age:      10,
+		IsActive: false,
+	}
+	result, _ := repo.Save(user)
+	lastID, _ := result.LastInsertId()
+	user.ID = int(lastID)
+
+	// 1. Perform explicit update
+	user.Email = "post_update@example.com"
+	user.Age = 100
+
+	result, err := repo.Update(user)
+	assert.NoError(t, err)
+
+	rowsAffected, err := result.RowsAffected()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rowsAffected)
+
+	// 2. Verify the update
+	foundUser := &TestUser{}
+	err = repo.FindByID(foundUser, user.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, "post_update@example.com", foundUser.Email)
+	assert.Equal(t, 100, foundUser.Age)
+
+	// 3. Test update on non-existent ID (should affect 0 rows)
+	t.Run("NonExistentID", func(t *testing.T) {
+		nonExistentUser := &TestUser{ID: 99999, Username: "foo", Email: "bar@baz.com"}
+		result, err := repo.Update(nonExistentUser)
+		assert.NoError(t, err)
+		rowsAffected, _ := result.RowsAffected()
+		assert.Equal(t, int64(0), rowsAffected)
+	})
+}
+
+func TestRepository_Delete(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Setup: Insert a record
+	user := &TestUser{
+		Username: "delete_test",
+		Email:    "delete@example.com",
+		Age:      60,
+		IsActive: true,
+	}
+	result, _ := repo.Save(user)
+	lastID, _ := result.LastInsertId()
+	user.ID = int(lastID)
+
+	// 1. Test successful deletion
+	result, err := repo.Delete(user)
+	assert.NoError(t, err)
+
+	rowsAffected, err := result.RowsAffected()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rowsAffected)
+
+	// 2. Verify deletion by trying to find the record
+	foundUser := &TestUser{}
+	err = repo.FindByID(foundUser, user.ID)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+
+	// 3. Test deleting a non-existent record (should affect 0 rows)
+	t.Run("NonExistentID", func(t *testing.T) {
+		nonExistentUser := &TestUser{ID: 99999}
+		result, err := repo.Delete(nonExistentUser)
+		assert.NoError(t, err)
+		rowsAffected, _ := result.RowsAffected()
+		assert.Equal(t, int64(0), rowsAffected)
+	})
+}


### PR DESCRIPTION
## Summary

*   Implement a Model-Centric `Repository` interface for high-level CRUD operations (`Save`, `FindByID`, `Update`, `Delete`).
*   Fix a critical bug in the underlying ORM's `Insert` logic to correctly handle auto-incrementing primary keys for SQLite.

## Details

This feature introduces a more idiomatic way to interact with the ORM by abstracting low-level SQL operations behind a `Repository` pattern.

Key changes include:
- New `pkg/model/model.go` defining the `Repository` interface and `ORMRepository` implementation.
- Reflection logic in `FindByID` to automatically populate model structs from database rows.
- Refactoring of `internal/orm/query.go` to exclude the primary key column from `INSERT` statements when the value is zero, ensuring correct auto-increment behavior across all adapters.
- Comprehensive unit tests for all repository methods.
- Updated `liteforge.go` and `README.md` to expose and document the new pattern.