### PR TITLE
Fix table creation for pointer models and improve docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ import "github.com/pballentine13/liteforge"
 ```
 
 ### 3. Define Your Data Models
-Use Go structs to represent your database tables. Use the db tag to customize the mapping between struct fields and database column names. Use the pk:"true" tag to mark the field as primary key with auto increment.
+Use Go structs to represent your database tables. Use the `db` tag to add column constraints (e.g., "not null", "unique"). Use the `pk:"true"` tag to mark the field as primary key with auto increment.
 ```go
 package model
 
 type User struct {
-    ID    int    `db:"id" pk:"true"` // Auto-incrementing primary key
-    Name  string                     // Maps to the "name" column
-    Email string                     // Maps to the "email" column
+    ID    int    `pk:"true"`         // Auto-incrementing primary key
+    Name  string `db:"not null"`     // Required field
+    Email string `db:"unique"`       // Unique constraint
 }
 ```
 
@@ -81,14 +81,14 @@ func main() {
 import (
 	"log"
 
-	"github.com/pballentine13/liteforge"  
+	"github.com/pballentine13/liteforge"
     "github.com/pballentine13/pkg/model"
 )
 
 func main() {
 	// ... (Database connection code from above)
 
-	err := liteforge.CreateTable(db, model.User{})
+	err := liteforge.CreateTable(db, &model.User{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/orm/adapter.go
+++ b/internal/orm/adapter.go
@@ -64,9 +64,12 @@ func (a *SQLiteAdapter) CreateTableSQL(model interface{}) (string, error) {
 		return "", errors.New("no model passed in. model was nil")
 	}
 
-	modelKind := reflect.TypeOf(model).Kind()
-	if modelKind != reflect.Struct {
-		return "", errors.New("no model passed in")
+	t := reflect.TypeOf(model)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return "", errors.New("model must be a struct or pointer to struct")
 	}
 	tableName := GetTableName(model)
 
@@ -77,7 +80,7 @@ func (a *SQLiteAdapter) CreateTableSQL(model interface{}) (string, error) {
 	if val.Kind() == reflect.Ptr {
 		val = val.Elem()
 	}
-	t := val.Type()
+	t = val.Type()
 	for i := 0; i < val.NumField(); i++ {
 		field := t.Field(i)
 		columnName := strings.ToLower(field.Name) // Default column name
@@ -170,9 +173,12 @@ func (a *PostgresAdapter) CreateTableSQL(model interface{}) (string, error) {
 		return "", errors.New("no model passed in. model was nil")
 	}
 
-	modelKind := reflect.TypeOf(model).Kind()
-	if modelKind != reflect.Struct {
-		return "", errors.New("no model passed in")
+	t := reflect.TypeOf(model)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return "", errors.New("model must be a struct or pointer to struct")
 	}
 	tableName := GetTableName(model)
 
@@ -183,7 +189,7 @@ func (a *PostgresAdapter) CreateTableSQL(model interface{}) (string, error) {
 	if val.Kind() == reflect.Ptr {
 		val = val.Elem()
 	}
-	t := val.Type()
+	t = val.Type()
 	for i := 0; i < val.NumField(); i++ {
 		field := t.Field(i)
 		columnName := strings.ToLower(field.Name) // Default column name

--- a/test/lightforge_test.go
+++ b/test/lightforge_test.go
@@ -108,6 +108,11 @@ func TestCreateTable(t *testing.T) {
 			model:   "not a struct",
 			wantErr: true,
 		},
+		{
+			name:    "Valid pointer to struct",
+			model:   &TestUser{},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes a bug in CreateTableSQL where passing a pointer to a struct model (e.g., &User{}) would fail with 'no model passed in' error. It also updates documentation and adds tests.

## Changes
- **Bug Fix**: Modified CreateTableSQL in SQLiteAdapter and PostgresAdapter to properly handle pointers to structs by dereferencing first.
- **Documentation**: Updated README.md with corrected db tag usage and pointer examples.
- **Tests**: Added test case for CreateTable with pointer models to ensure the fix works.

## Testing
- All existing tests pass.
- New test confirms pointer support.
- No breaking changes.

Closes #<issue_number> if applicable.